### PR TITLE
fix(healthcheck): issues sort

### DIFF
--- a/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
+++ b/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
@@ -44,8 +44,8 @@ const mapStatusToPriority: Record<StatusFlag, number> = {
 
 const sortIssues = (data: IssueLog[]): IssueLog[] => {
     return data.slice().sort((a, b) => {
-        const aPriority = a.status ? mapStatusToPriority[a.status] || 0 : 0;
-        const bPriority = b.status ? mapStatusToPriority[b.status] || 0 : 0;
+        const aPriority = mapStatusToPriority[a.status ?? StatusFlag.UNSPECIFIED];
+        const bPriority = mapStatusToPriority[b.status ?? StatusFlag.UNSPECIFIED];
 
         return aPriority - bPriority;
     });

--- a/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
+++ b/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
@@ -42,7 +42,7 @@ const mapStatusToPriority: Record<StatusFlag, number> = {
 };
 
 const sortIssues = (data: IssueLog[]): IssueLog[] => {
-    return data.sort((a, b) => {
+    return data.slice().sort((a, b) => {
         const aPriority = a.status ? mapStatusToPriority[a.status] || 0 : 0;
         const bPriority = b.status ? mapStatusToPriority[b.status] || 0 : 0;
 

--- a/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
+++ b/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
@@ -1,6 +1,7 @@
 import {createSelector} from '@reduxjs/toolkit';
 
-import type {IssueLog, StatusFlag} from '../../../types/api/healthcheck';
+import type {IssueLog} from '../../../types/api/healthcheck';
+import {StatusFlag} from '../../../types/api/healthcheck';
 import type {RootState} from '../../defaultStore';
 import {api} from '../api';
 

--- a/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
+++ b/src/store/reducers/healthcheckInfo/healthcheckInfo.ts
@@ -31,12 +31,14 @@ export const healthcheckApi = api.injectEndpoints({
     overrideExisting: 'throw',
 });
 
-const mapStatusToPriority: Partial<Record<StatusFlag, number>> = {
-    RED: 0,
-    ORANGE: 1,
-    YELLOW: 2,
-    BLUE: 3,
-    GREEN: 4,
+const mapStatusToPriority: Record<StatusFlag, number> = {
+    [StatusFlag.RED]: 0,
+    [StatusFlag.ORANGE]: 1,
+    [StatusFlag.YELLOW]: 2,
+    [StatusFlag.BLUE]: 3,
+    [StatusFlag.GREEN]: 4,
+    [StatusFlag.GREY]: 5,
+    [StatusFlag.UNSPECIFIED]: 6,
 };
 
 const sortIssues = (data: IssueLog[]): IssueLog[] => {
@@ -78,7 +80,8 @@ const selectIssuesTreesRoots = createSelector(getIssuesLog, (issues = []) => get
 export const selectLeavesIssues = createSelector(
     [getIssuesLog, selectIssuesTreesRoots],
     (data = [], roots = []) => {
-        return roots.map((root) => getLeavesFromTree(data, root)).flat();
+        const leaves = roots.map((root) => getLeavesFromTree(data, root)).flat();
+        return sortIssues(leaves);
     },
 );
 


### PR DESCRIPTION
## Summary
- define priority for all healthcheck statuses
- sort leaf issues by descending criticality

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a72ecc78c832c9179604a58c6311b